### PR TITLE
Allow use of csv file for running multiple inferences

### DIFF
--- a/src/nomad_crystallm/actions/__init__.py
+++ b/src/nomad_crystallm/actions/__init__.py
@@ -19,7 +19,7 @@ class CrystaLLMInferenceEntryPoint(ActionEntryPoint):
         from nomad.actions import Action
 
         from nomad_crystallm.actions.activities import (
-            construct_model_input,
+            construct_prompts,
             get_model,
             run_inference,
             write_results,
@@ -29,7 +29,7 @@ class CrystaLLMInferenceEntryPoint(ActionEntryPoint):
         return Action(
             task_queue=self.task_queue,
             workflow=InferenceWorkflow,
-            activities=[get_model, construct_model_input, run_inference, write_results],
+            activities=[get_model, construct_prompts, run_inference, write_results],
         )
 
 

--- a/src/nomad_crystallm/actions/activities.py
+++ b/src/nomad_crystallm/actions/activities.py
@@ -63,18 +63,25 @@ async def construct_prompts(
                 f'CSV file must contain the following columns: {required_columns}'
             )
         for _, row in df.iterrows():
+            if pd.isna(row['input_composition']):
+                raise ValueError('input_composition cannot be empty in the CSV file.')
+            input_composition = str(row['input_composition'])
+            input_num_formula_units_per_cell = (
+                str(int(row['input_num_formula_units_per_cell']))
+                if not pd.isna(row['input_num_formula_units_per_cell'])
+                else ''
+            )
+            input_space_group = (
+                str(row['input_space_group'])
+                if not pd.isna(row['input_space_group'])
+                else ''
+            )
             outputs.append(
                 ConstructPromptOutput(
                     prompt=construct_prompt(
-                        str(row['input_composition'])
-                        if not pd.isna(row['input_composition'])
-                        else '',
-                        str(int(row['input_num_formula_units_per_cell']))
-                        if not pd.isna(row['input_num_formula_units_per_cell'])
-                        else '',
-                        str(row['input_space_group'])
-                        if not pd.isna(row['input_space_group'])
-                        else '',
+                        input_composition,
+                        input_num_formula_units_per_cell,
+                        input_space_group,
                     ),
                     composition=str(row['input_composition']),
                 )

--- a/src/nomad_crystallm/actions/activities.py
+++ b/src/nomad_crystallm/actions/activities.py
@@ -1,5 +1,3 @@
-import pandas as pd
-from nomad.datamodel import ServerContext
 from temporalio import activity
 
 from nomad_crystallm.actions.shared import (
@@ -25,6 +23,9 @@ async def get_model(model_name):
 async def construct_prompts(
     data: ConstructPromptInput,
 ) -> list[ConstructPromptOutput]:
+    import pandas as pd
+    from nomad.datamodel import ServerContext
+
     from .llm import construct_prompt
 
     outputs = []
@@ -65,9 +66,15 @@ async def construct_prompts(
             outputs.append(
                 ConstructPromptOutput(
                     prompt=construct_prompt(
-                        str(row['input_composition']),
-                        str(row['input_num_formula_units_per_cell']),
-                        str(row['input_space_group']),
+                        str(row['input_composition'])
+                        if not pd.isna(row['input_composition'])
+                        else '',
+                        str(int(row['input_num_formula_units_per_cell']))
+                        if not pd.isna(row['input_num_formula_units_per_cell'])
+                        else '',
+                        str(row['input_space_group'])
+                        if not pd.isna(row['input_space_group'])
+                        else '',
                     ),
                     composition=str(row['input_composition']),
                 )

--- a/src/nomad_crystallm/actions/llm.py
+++ b/src/nomad_crystallm/actions/llm.py
@@ -173,7 +173,7 @@ def evaluate_model(inference_input: InferenceInput) -> InferenceOutput:
     model = GPT(gptconf)
     state_dict = checkpoint['model']
     unwanted_prefix = '_orig_mod.'
-    for k, _ in list(state_dict.items()):
+    for k in list(state_dict.keys()):
         if k.startswith(unwanted_prefix):
             state_dict[k[len(unwanted_prefix) :]] = state_dict.pop(k)
     model.load_state_dict(state_dict)

--- a/src/nomad_crystallm/actions/llm.py
+++ b/src/nomad_crystallm/actions/llm.py
@@ -277,7 +277,7 @@ def write_entry_archive(cif_paths, result: WriteResultsInput) -> str:
     )
     # Create an entry for the inference results
     upload = get_upload(result.upload_id, result.user_id)
-    upload.parser_level = -1
+    upload.parser_level = -1  # avoid parser_level=None when process_local=False
     context = ServerContext(upload)
     with context.update_entry(rel_mainfile_path, write=True, process=True) as archive:
         archive['data'] = inference_result.m_to_dict(with_root_def=True)

--- a/src/nomad_crystallm/actions/shared.py
+++ b/src/nomad_crystallm/actions/shared.py
@@ -40,17 +40,50 @@ class InferenceSettingsInput(BaseModel):
     )
 
 
-class InferenceUserInput(BaseModel):
-    upload_id: str = Field(..., description='ID of the NOMAD upload to save results.')
-    user_id: str = Field(..., description='ID of the user making the request.')
+class PromptGenerationTextInput(BaseModel):
     prompt_generation_inputs: list[PromptGenerationInput] = Field(
         ...,
         description='List of prompt generation inputs.',
         title='Prompt Generation Inputs',
     )
+    input_type: Literal['text']
+
+
+class PromptGenerationFileInput(BaseModel):
+    filepath: str = Field(
+        ...,
+        description='Path of a CSV file containing prompt generation inputs, '
+        'relative to the raw folder of the specified upload.',
+        title='Filepath',
+    )
+    input_type: Literal['filepath']
+
+
+class InferenceUserInput(BaseModel):
+    upload_id: str = Field(..., description='ID of the NOMAD upload to save results.')
+    user_id: str = Field(..., description='ID of the user making the request.')
+    prompter: PromptGenerationTextInput | PromptGenerationFileInput = Field(
+        discriminator='input_type'
+    )
     inference_settings: InferenceSettingsInput = Field(
         ..., description='Inference settings for the model.', title='Inference Settings'
     )
+
+
+@dataclass
+class ConstructPromptInput:
+    """
+    Input data for constructing prompts.
+
+    Attributes:
+    - prompter: Prompt generation input, either text or file-based.
+    - upload_id: ID of the NOMAD upload to save results.
+    - user_id: ID of the user making the request.
+    """
+
+    prompter: PromptGenerationTextInput | PromptGenerationFileInput
+    upload_id: str
+    user_id: str
 
 
 @dataclass

--- a/src/nomad_crystallm/actions/shared.py
+++ b/src/nomad_crystallm/actions/shared.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 
 class PromptGenerationInput(BaseModel):
@@ -33,7 +34,7 @@ class InferenceSettingsInput(BaseModel):
         'bfloat16', description='Data type for the model (based on PyTorch data types).'
     )
     compile: bool = Field(
-        False, description='Whether to compile the model for faster inference.'
+        True, description='Whether to compile the model for faster inference.'
     )
 
 
@@ -43,7 +44,7 @@ class PromptGenerationTextInput(BaseModel):
         description='List of prompt generation inputs.',
         title='Prompt Generation Inputs',
     )
-    input_type: Literal['text'] = Field(hidden=True)
+    input_type: SkipJsonSchema[Literal['text']]
 
 
 class PromptGenerationFileInput(BaseModel):
@@ -53,7 +54,7 @@ class PromptGenerationFileInput(BaseModel):
         'relative to the raw folder of the specified upload.',
         title='Filepath',
     )
-    input_type: Literal['filepath']
+    input_type: SkipJsonSchema[Literal['filepath']]
 
 
 class InferenceUserInput(BaseModel):

--- a/src/nomad_crystallm/actions/shared.py
+++ b/src/nomad_crystallm/actions/shared.py
@@ -35,9 +35,6 @@ class InferenceSettingsInput(BaseModel):
     compile: bool = Field(
         False, description='Whether to compile the model for faster inference.'
     )
-    generate_cif: bool = Field(
-        True, description='If True, the model will generate CIF files.'
-    )
 
 
 class PromptGenerationTextInput(BaseModel):
@@ -46,7 +43,7 @@ class PromptGenerationTextInput(BaseModel):
         description='List of prompt generation inputs.',
         title='Prompt Generation Inputs',
     )
-    input_type: Literal['text']
+    input_type: Literal['text'] = Field(hidden=True)
 
 
 class PromptGenerationFileInput(BaseModel):
@@ -87,9 +84,23 @@ class ConstructPromptInput:
 
 
 @dataclass
-class InferenceModelInput:
+class ConstructPromptOutput:
     """
-    Model input data for the inference workflow.
+    Output data for prompt construction.
+
+    Attributes:
+    - prompt: Constructed prompt.
+    - composition: Composition corresponding to the prompt.
+    """
+
+    prompt: str
+    composition: str
+
+
+@dataclass
+class InferenceInput:
+    """
+    Input data for model inference.
 
     Attributes:
 
@@ -97,36 +108,47 @@ class InferenceModelInput:
     - inference_settings: Settings for the model inference.
     """
 
-    prompts: list[str]
+    constructed_prompt: ConstructPromptOutput
     inference_settings: InferenceSettingsInput
 
 
 @dataclass
-class InferenceResultsInput:
+class InferenceOutput:
     """
-    CIF Results input data for the inference workflow.
+    Output data from the model inference.
+
+    Attributes:
+    - generated_samples: List of generated samples from the model. Number of samples
+        is determined by the `num_samples` attribute in InferenceSettingsInput.
+    """
+
+    generated_samples: list[str]
+
+
+@dataclass
+class WriteResultsInput:
+    """
+    Input data for writing results as NOMAD entries.
 
     Attributes:
     - upload_id: If generate_cif, write the generate CIF files to the upload.
     - user_id: User making the request
-    - action_instance_id: ID of the action instance.
-    - composition: Composition of the material.
+    - action_instance_id: ID of the action instance; will be used to create a subfolder
+        under the raw folder of the upload.
+    - relative_cif_dir: Directory for the CIF files relative to the action instance dir.
+    - constructed_prompt: Composition of the material.
     - prompt: Prompt used for the model.
     - inference_settings: Settings for the model inference.
-    - generated_samples: List to store generated samples from the model.
-    - generate_cif: If True, the model will generate CIF files.
-    - relative_cif_dir: Path of directory containing CIF relative to action directory.
+    - inference_output: Output from the model containing generated samples.
     """
 
     upload_id: str
     user_id: str
     action_instance_id: str
-    composition: str
-    prompt: str
-    inference_settings: InferenceSettingsInput
-    generated_samples: list[str]
-    generate_cif: bool
     relative_cif_dir: str
+    constructed_prompt: ConstructPromptOutput
+    inference_settings: InferenceSettingsInput
+    inference_output: InferenceOutput
 
 
 SpaceGroupLiteral = Literal[

--- a/src/nomad_crystallm/actions/shared.py
+++ b/src/nomad_crystallm/actions/shared.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, Field
-from pydantic.json_schema import SkipJsonSchema
 
 
 class PromptGenerationInput(BaseModel):
@@ -34,7 +33,7 @@ class InferenceSettingsInput(BaseModel):
         'bfloat16', description='Data type for the model (based on PyTorch data types).'
     )
     compile: bool = Field(
-        True, description='Whether to compile the model for faster inference.'
+        False, description='Whether to compile the model for faster inference.'
     )
 
 
@@ -44,7 +43,7 @@ class PromptGenerationTextInput(BaseModel):
         description='List of prompt generation inputs.',
         title='Prompt Generation Inputs',
     )
-    input_type: SkipJsonSchema[Literal['text']]
+    input_type: Literal['text'] = Field(hidden=True)
 
 
 class PromptGenerationFileInput(BaseModel):
@@ -54,7 +53,7 @@ class PromptGenerationFileInput(BaseModel):
         'relative to the raw folder of the specified upload.',
         title='Filepath',
     )
-    input_type: SkipJsonSchema[Literal['filepath']]
+    input_type: Literal['filepath']
 
 
 class InferenceUserInput(BaseModel):

--- a/src/nomad_crystallm/actions/workflow.py
+++ b/src/nomad_crystallm/actions/workflow.py
@@ -4,12 +4,13 @@ from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
     from nomad_crystallm.actions.activities import (
-        construct_model_input,
+        construct_prompts,
         get_model,
         run_inference,
         write_results,
     )
     from nomad_crystallm.actions.shared import (
+        ConstructPromptInput,
         InferenceModelInput,
         InferenceResultsInput,
         InferenceUserInput,
@@ -21,8 +22,12 @@ class InferenceWorkflow:
     @workflow.run
     async def run(self, data: InferenceUserInput) -> list[str]:
         constructed_prompts = await workflow.execute_activity(
-            construct_model_input,
-            data.prompt_generation_inputs,
+            construct_prompts,
+            ConstructPromptInput(
+                prompter=data.prompter,
+                upload_id=data.upload_id,
+                user_id=data.user_id,
+            ),
             start_to_close_timeout=timedelta(seconds=60),
         )
         model_data = InferenceModelInput(

--- a/src/nomad_crystallm/actions/workflow.py
+++ b/src/nomad_crystallm/actions/workflow.py
@@ -11,16 +11,16 @@ with workflow.unsafe.imports_passed_through():
     )
     from nomad_crystallm.actions.shared import (
         ConstructPromptInput,
-        InferenceModelInput,
-        InferenceResultsInput,
+        InferenceInput,
         InferenceUserInput,
+        WriteResultsInput,
     )
 
 
 @workflow.defn
 class InferenceWorkflow:
     @workflow.run
-    async def run(self, data: InferenceUserInput) -> list[str]:
+    async def run(self, data: InferenceUserInput) -> None:
         constructed_prompts = await workflow.execute_activity(
             construct_prompts,
             ConstructPromptInput(
@@ -28,39 +28,34 @@ class InferenceWorkflow:
                 upload_id=data.upload_id,
                 user_id=data.user_id,
             ),
-            start_to_close_timeout=timedelta(seconds=60),
-        )
-        model_data = InferenceModelInput(
-            prompts=constructed_prompts,
-            inference_settings=data.inference_settings,
+            start_to_close_timeout=timedelta(hours=1),
         )
         await workflow.execute_activity(
             get_model,
-            model_data,
-            start_to_close_timeout=timedelta(seconds=600),
+            data.inference_settings.model_name,
+            start_to_close_timeout=timedelta(hours=1),
         )
-        generated_compositions_samples = await workflow.execute_activity(
-            run_inference,
-            model_data,
-            start_to_close_timeout=timedelta(seconds=600),
-        )
-        for i, generated_samples in enumerate(generated_compositions_samples):
+        for idx, constructed_prompt in enumerate(constructed_prompts):
+            inference_output = await workflow.execute_activity(
+                run_inference,
+                InferenceInput(
+                    constructed_prompt=constructed_prompt,
+                    inference_settings=data.inference_settings,
+                ),
+                start_to_close_timeout=timedelta(hours=1),
+            )
             await workflow.execute_activity(
                 write_results,
-                InferenceResultsInput(
+                WriteResultsInput(
                     user_id=data.user_id,
                     upload_id=data.upload_id,
                     action_instance_id=workflow.info().workflow_id,
-                    composition=data.prompt_generation_inputs[i].input_composition,
-                    prompt=model_data.prompts[i],
-                    inference_settings=model_data.inference_settings,
-                    generated_samples=generated_samples,
-                    generate_cif=data.inference_settings.generate_cif,
                     relative_cif_dir=(
-                        f'composition_{i + 1}_'
-                        f'{data.prompt_generation_inputs[i].input_composition}'
+                        f'composition_{idx + 1}_{constructed_prompt.composition}'
                     ),
+                    constructed_prompt=constructed_prompt,
+                    inference_settings=data.inference_settings,
+                    inference_output=inference_output,
                 ),
-                start_to_close_timeout=timedelta(seconds=60),
+                start_to_close_timeout=timedelta(hours=1),
             )
-        return generated_compositions_samples


### PR DESCRIPTION
- Use a `.csv` file to send a list of prompts. The following column names will be looked for and `input_composition` column should always have a valid formula, other columns are optional:
  ```py
  'input_composition'
  'input_num_formula_units_per_cell'
  'input_space_group'
  ```
- Split into one inference activity per prompt rather than using one inference activity for all prompts. Avoids sending huge collections of results over gRPC.
- Use dataclasses for outputs of activities