### PR TITLE
Parallelize and batch

### DIFF
--- a/src/nomad_crystallm/actions/inference/__init__.py
+++ b/src/nomad_crystallm/actions/inference/__init__.py
@@ -19,11 +19,15 @@ class CrystaLLMInferenceEntryPoint(ActionEntryPoint):
             run_inference,
             write_results,
         )
-        from nomad_crystallm.actions.inference.workflow import InferenceWorkflow
+        from nomad_crystallm.actions.inference.workflow import (
+            CrystallmWorkflow,
+            InferenceWorkflow,
+        )
 
         return Action(
             task_queue=self.task_queue,
-            workflow=InferenceWorkflow,
+            workflow=CrystallmWorkflow,
+            child_workflows=[InferenceWorkflow],
             activities=[get_model, get_prompt, run_inference, write_results],
         )
 

--- a/src/nomad_crystallm/actions/inference/models.py
+++ b/src/nomad_crystallm/actions/inference/models.py
@@ -278,7 +278,9 @@ class InferenceSettingsInput(BaseModel):
     compile: bool = Field(
         False, description='Whether to compile the Torch model for faster inference.'
     )
-    batch_size: int = Field(16, ge=1, description='Batch size for model inference.')
+    batch_size: int = Field(
+        16, ge=1, le=32, description='Batch size for model inference.'
+    )
 
 
 class CrystallmUserInput(BaseModel):

--- a/src/nomad_crystallm/actions/inference/models.py
+++ b/src/nomad_crystallm/actions/inference/models.py
@@ -263,15 +263,20 @@ class InferenceSettingsInput(BaseModel):
         3000, ge=1, le=10000, description='Maximum number of tokens to generate.'
     )
     temperature: float = Field(
-        0.8, ge=0.0, le=1.0, description='Temperature for sampling.'
+        0.8, ge=0.0, le=1.0, description='Temperature for token sampling.'
     )
-    top_k: int = Field(10, ge=1, le=100, description='Top-k sampling.')
+    top_k: int = Field(
+        10,
+        ge=1,
+        le=100,
+        description='Number of top most probable tokens used for Top-k token sampling.',
+    )
     seed: int = Field(1337, ge=0, description='Random seed for reproducibility.')
     dtype: Literal['bfloat16', 'float16', 'float32'] = Field(
         'bfloat16', description='Data type for the model (based on PyTorch data types).'
     )
     compile: bool = Field(
-        False, description='Whether to compile the model for faster inference.'
+        False, description='Whether to compile the Torch model for faster inference.'
     )
     batch_size: int = Field(16, ge=1, description='Batch size for model inference.')
 

--- a/src/nomad_crystallm/actions/inference/models.py
+++ b/src/nomad_crystallm/actions/inference/models.py
@@ -273,9 +273,10 @@ class InferenceSettingsInput(BaseModel):
     compile: bool = Field(
         False, description='Whether to compile the model for faster inference.'
     )
+    batch_size: int = Field(16, ge=1, description='Batch size for model inference.')
 
 
-class InferenceUserInput(BaseModel):
+class CrystallmUserInput(BaseModel):
     upload_id: str = Field(..., description='ID of the NOMAD upload to save results.')
     user_id: str = Field(..., description='ID of the user making the request.')
     prompt_construction_inputs: list[PromptConstructionInput] = Field(
@@ -299,8 +300,22 @@ class InferenceInput:
     - inference_settings: Settings for the model inference.
     """
 
-    prompt: str
+    user_id: str
+    upload_id: str
+    prompts: list[str]
     inference_settings: InferenceSettingsInput
+
+
+@dataclass
+class InferenceOutput:
+    """
+    Output data from model inference.
+
+    Attributes:
+    - generated_samples: List of generated samples from the model.
+    """
+
+    generated_samples: list[str]
 
 
 @dataclass

--- a/src/nomad_crystallm/actions/inference/utils.py
+++ b/src/nomad_crystallm/actions/inference/utils.py
@@ -134,8 +134,8 @@ def evaluate_model(inference_input: InferenceInput) -> list[str]:
     - inference_input (InferenceInput): The input parameters for inference.
 
     Returns:
-    - list[str]: List of generated samples from the model. Number of samples
-        is determined by `inference_input.inference_settings.num_samples`.
+    - list[str]: List of generated samples from the model, with maximum length equal
+        to the `inference_input.inference_settings.batch_size`.
     """
     torch.manual_seed(inference_input.inference_settings.seed)
     torch.cuda.manual_seed(inference_input.inference_settings.seed)
@@ -180,21 +180,20 @@ def evaluate_model(inference_input: InferenceInput) -> list[str]:
 
     # run generation
     # encode the beginning of the prompt
-    start_ids = encode(tokenizer.tokenize_cif(inference_input.prompt))
-    x = torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...]
-    generated_samples = []
+    start_ids = [
+        encode(tokenizer.tokenize_cif(prompt)) for prompt in inference_input.prompts
+    ]
+    x = torch.tensor(start_ids, dtype=torch.long, device=device)
     with torch.no_grad():
         with ctx:
-            for k in range(inference_input.inference_settings.num_samples):
-                y = model.generate(
-                    x,
-                    inference_input.inference_settings.max_new_tokens,
-                    temperature=inference_input.inference_settings.temperature,
-                    top_k=inference_input.inference_settings.top_k,
-                )
-                generated_samples.append(decode(y[0].tolist()))
+            y = model.generate(
+                x,
+                inference_input.inference_settings.max_new_tokens,
+                temperature=inference_input.inference_settings.temperature,
+                top_k=inference_input.inference_settings.top_k,
+            )
 
-    return generated_samples
+    return model.postprocess_generation(y)
 
 
 def postprocess(cif: str, fname: str, logger: 'LoggerAdapter') -> str:

--- a/src/nomad_crystallm/actions/inference/utils.py
+++ b/src/nomad_crystallm/actions/inference/utils.py
@@ -164,7 +164,6 @@ def evaluate_model(inference_input: InferenceInput) -> list[str]:
 
     tokenizer = CIFTokenizer()
     encode = tokenizer.encode
-    decode = tokenizer.decode
 
     model_path = os.path.join(
         action_artifacts_dir(),

--- a/src/nomad_crystallm/actions/inference/utils.py
+++ b/src/nomad_crystallm/actions/inference/utils.py
@@ -8,15 +8,6 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 import torch
-from crystallm import (
-    GPT,
-    CIFTokenizer,
-    GPTConfig,
-    extract_space_group_symbol,
-    get_atomic_props_block_for_formula,
-    remove_atom_props_block,
-    replace_symmetry_operators,
-)
 from nomad.actions.manager import action_artifacts_dir, get_upload_files
 from nomad.datamodel import ServerContext
 from pymatgen.core import Composition
@@ -30,6 +21,22 @@ from nomad_crystallm.schemas.schema import (
     InferenceSettings,
 )
 from nomad_crystallm.utils import get_upload
+
+try:
+    from crystallm import (
+        GPT,
+        CIFTokenizer,
+        GPTConfig,
+        extract_space_group_symbol,
+        get_atomic_props_block_for_formula,
+        remove_atom_props_block,
+        replace_symmetry_operators,
+    )
+except ImportError as e:
+    raise ImportError(
+        'Unable to import the "crystallm" package, which is required for CrystaLLM '
+        'actions.'
+    ) from e
 
 if TYPE_CHECKING:
     from logging import LoggerAdapter

--- a/src/nomad_crystallm/actions/inference/workflow.py
+++ b/src/nomad_crystallm/actions/inference/workflow.py
@@ -113,7 +113,8 @@ class CrystallmWorkflow:
                         upload_id=data.upload_id,
                         action_instance_id=workflow.info().workflow_id,
                         relative_cif_dir=(
-                            f'composition_{idx + 1}_{prompt_construction_input.composition}'
+                            'composition_'
+                            f'{idx + 1}_{prompt_construction_input.composition}'
                         ),
                         composition=prompt_construction_input.composition,
                         prompt=prompts[idx],

--- a/src/nomad_crystallm/actions/inference/workflow.py
+++ b/src/nomad_crystallm/actions/inference/workflow.py
@@ -11,8 +11,9 @@ with workflow.unsafe.imports_passed_through():
         write_results,
     )
     from nomad_crystallm.actions.inference.models import (
+        CrystallmUserInput,
         InferenceInput,
-        InferenceUserInput,
+        InferenceOutput,
         WriteResultsInput,
     )
 
@@ -20,7 +21,21 @@ with workflow.unsafe.imports_passed_through():
 @workflow.defn
 class InferenceWorkflow:
     @workflow.run
-    async def run(self, data: InferenceUserInput) -> None:
+    async def run(self, data: InferenceInput) -> InferenceOutput:
+        generated_samples = await workflow.execute_activity(
+            run_inference,
+            data,
+            start_to_close_timeout=timedelta(hours=24),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+        return InferenceOutput(generated_samples=generated_samples)
+
+
+@workflow.defn
+class CrystallmWorkflow:
+    @workflow.run
+    async def run(self, data: CrystallmUserInput) -> None:
         retry_policy = RetryPolicy(maximum_attempts=3)
         await workflow.execute_activity(
             get_model,
@@ -28,24 +43,51 @@ class InferenceWorkflow:
             start_to_close_timeout=timedelta(hours=1),
             retry_policy=retry_policy,
         )
-        for idx, prompt_construction_input in enumerate(
-            data.prompt_construction_inputs
-        ):
+
+        prompts = []  # list of all prompts along with as many duplicates as num_samples
+        for prompt_construction_input in data.prompt_construction_inputs:
             prompt = await workflow.execute_activity(
                 get_prompt,
                 prompt_construction_input,
                 start_to_close_timeout=timedelta(hours=1),
                 retry_policy=retry_policy,
             )
-            generated_samples = await workflow.execute_activity(
-                run_inference,
+            prompts.extend([prompt] * data.inference_settings.num_samples)
+
+        num_batches = len(prompts) // data.inference_settings.batch_size
+        if len(prompts) % data.inference_settings.batch_size != 0:
+            num_batches += 1
+
+        generated_samples_all_batches = []
+        for batch_idx in range(num_batches):
+            # create a child workflow for each batch
+            range_start = batch_idx * data.inference_settings.batch_size
+            range_end = min(
+                (batch_idx + 1) * data.inference_settings.batch_size, len(prompts)
+            )
+            batch_prompts = prompts[range_start:range_end]
+            inference_output = await workflow.execute_child_workflow(
+                InferenceWorkflow.run,
                 InferenceInput(
-                    prompt=prompt,
+                    user_id=data.user_id,
+                    upload_id=data.upload_id,
+                    prompts=batch_prompts,
                     inference_settings=data.inference_settings,
                 ),
-                start_to_close_timeout=timedelta(hours=1),
-                retry_policy=retry_policy,
+                id=f'{workflow.info().workflow_id}_inference_batch_{batch_idx}',
+                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                retry_policy=RetryPolicy(maximum_attempts=1),
             )
+            generated_samples_all_batches.extend(inference_output.generated_samples)
+
+        for idx, prompt_construction_input in enumerate(
+            data.prompt_construction_inputs
+        ):
+            prompt = prompts[idx * data.inference_settings.num_samples]
+            generated_samples = generated_samples_all_batches[
+                idx * data.inference_settings.num_samples : (idx + 1)
+                * data.inference_settings.num_samples
+            ]
             await workflow.execute_activity(
                 write_results,
                 WriteResultsInput(

--- a/src/nomad_crystallm/schemas/schema.py
+++ b/src/nomad_crystallm/schemas/schema.py
@@ -19,8 +19,8 @@ from nomad.normalizing.topology import add_system, add_system_info
 from pymatgen.core import Composition
 
 from nomad_crystallm.actions.inference.models import (
+    CrystallmUserInput,
     InferenceSettingsInput,
-    InferenceUserInput,
     PromptConstructionInput,
 )
 from nomad_crystallm.utils import get_reference_from_mainfile
@@ -88,6 +88,10 @@ class InferenceSettings(ArchiveSection):
     compile = Quantity(
         type=bool,
         description='Whether to compile the model for faster inference.',
+    )
+    batch_size = Quantity(
+        type=int,
+        description='Batch size for model inference.',
     )
 
 
@@ -242,6 +246,12 @@ class InferenceSettingsForm(ArchiveSection):
     compile.default = False
     compile.m_annotations['eln'] = ELNAnnotation(
         component=ELNComponentEnum.BoolEditQuantity,
+    )
+
+    batch_size = InferenceSettings.batch_size.m_copy(deep=True)
+    batch_size.default = 16
+    batch_size.m_annotations['eln'] = ELNAnnotation(
+        component=ELNComponentEnum.NumberEditQuantity,
     )
 
 
@@ -418,8 +428,9 @@ class CrystaLLMInferenceForm(EntryData):
             seed=self.inference_settings.seed,
             dtype=self.inference_settings.dtype,
             compile=self.inference_settings.compile,
+            batch_size=self.inference_settings.batch_size,
         )
-        input_data = InferenceUserInput(
+        input_data = CrystallmUserInput(
             user_id=archive.metadata.authors[0].user_id,
             upload_id=archive.metadata.upload_id,
             prompt_construction_inputs=prompt_construction_inputs,


### PR DESCRIPTION
- Make inference as a child workflow.
- Split total number of prompts into batches and trigger one child workflow for each batch.
- Processes multiple prompts in one forward pass of the model (batch)
- Use asyncio gather for prompt generation and results writing

Each prompt will be processed `num_samples` times, meaning that if there are `m` prompts and `num_samples=n` per prompt, a total of `mxn` inferences will happen. These inferences are divided into batches based on the `batch_size` and each batch is processed by one child workflow.

- Since the `batch_size` has a upper limit, not more than 32 prompts can be processed in one child workflow. If we can implement a config setting to throttle the number of workflows (parent and child together) per action_queue per user per unit time, we can effectively throttle the number of prompts processed.
